### PR TITLE
Add quick-lint-js linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 
 - [Deno Lint](https://github.com/denoland/deno_lint)
 - [Flow](https://flow.org/), a static type checker for JavaScript, written in OCaml
+- [quick-lint-js](https://quick-lint-js.com/), written in C++
 - [RSLint](https://github.com/rslint/rslint), a (WIP) Extremely fast JavaScript and TypeScript linter, written in Rust
 
 ## Formatters


### PR DESCRIPTION
I am developing a JavaScript linter called quick-lint-js. Add it to the
list for some exposure.

Note: quick-lint-js has not reach 1.0 yet.