### PR TITLE
fix: replace Rome with the Biome

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ _If you can think of a more appropriate category for the items below, PRs welcom
 - [Volta](https://volta.sh/) - JavaScript Tool Manager, written in Rust.
 - [es-module-lexer](https://github.com/guybedford/es-module-lexer) - JavaScript module syntax lexer, written in C.
 - [npm-dep-check-rust](https://github.com/saiumesh535/npm-dep-chek-rust) - Find unused dependencies in Node.js applications, written in Rust.
-- [Rome](https://rome.tools) - Linter, compiler, bundler, and more for JavaScript, TypeScript, JSON, HTML, Markdown, and CSS, 🚧 currently being re-written in Rust ([source](https://rome.tools/blog/2021/09/21/rome-will-be-rewritten-in-rust)).
+- [Biome](https://biomejs.dev) - Linter, formatter, analyzer for JavaScript, TypeScript, and JSON. Succesor of the [Rome](https://rome.tools).
 - [Wrangler](https://github.com/cloudflare/wrangler) - CLI tool to develop Clouflare Workers, written in Rust.
 - [Turborepo](https://github.com/vercel/turborepo) - The high-performance build system for JavaScript & TypeScript codebases, written in Go, 🚧 currently being migrated to Rust ([source](https://vercel.com/blog/turborepo-migration-go-rust)).
 - [Blueboat](https://github.com/losfair/blueboat) – all-in-one, multi-tenant serverless JavaScript runtime, written in Rust.


### PR DESCRIPTION
[Biome](https://biomejs.dev/) is the official fork of Rome and it will continue to be Rome’s legacy. ( https://biomejs.dev/blog/annoucing-biome )

[Rome's repo is archived](https://github.com/rome/tools) and it says it won't be maintained anymore by the same people that maintained it so far.

